### PR TITLE
[TASK] Add schedule configuration to GitHub Action workflows

### DIFF
--- a/.github/workflows/cgl.yml
+++ b/.github/workflows/cgl.yml
@@ -3,6 +3,8 @@ name: code-quality
 on:
   push:
   pull_request:
+  schedule:
+    - cron:  '56 4 * * *'
 
 jobs:
   lint:

--- a/.github/workflows/tests-11.5.yml
+++ b/.github/workflows/tests-11.5.yml
@@ -3,6 +3,8 @@ name: tests 11.5
 on:
   push:
   pull_request:
+  schedule:
+    - cron:  '56 4 * * *'
 
 jobs:
   unit:

--- a/.github/workflows/tests-12.0.yml
+++ b/.github/workflows/tests-12.0.yml
@@ -3,6 +3,8 @@ name: tests 12.0
 on:
   push:
   pull_request:
+  schedule:
+    - cron:  '56 4 * * *'
     
 jobs:
   unit:

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -3,6 +3,8 @@ name: tests main
 on:
   push:
   pull_request:
+  schedule:
+    - cron:  '56 4 * * *'
     
 jobs:
   unit:


### PR DESCRIPTION
It make some sense to have recurring testing enabled, using already defined CI jobs for pull-request and/or push events.

This change add schedule configurations to all existing GitHub Action worklows to add this kind of recurring job executions, which can be called `nightlies`.

Resolves #10