### PR TITLE
[BUGFIX] Add return type to PhpDomainCommand::execute()

### DIFF
--- a/Classes/Command/PhpDomainCommand.php
+++ b/Classes/Command/PhpDomainCommand.php
@@ -47,7 +47,7 @@ class PhpDomainCommand extends Command
      * @param OutputInterface $output
      * @return int error code
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"php": "^8.1 || ^8.2 || ^8.3",
+		"php": "^8.1",
 		"symfony/console": "^6.4 || ^7.0",
 		"typo3/cms-core": "^11.5 || ^12.4 || dev-main"
 	},

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,9 @@
 		}
 	],
 	"require": {
-		"php": "^8.1 || ^8.2",
-		"typo3/cms-core": "^11.5 || ^12.0 || dev-main"
+		"php": "^8.1 || ^8.2 || ^8.3",
+		"symfony/console": "^6.4 || ^7.0",
+		"typo3/cms-core": "^11.5 || ^12.4 || dev-main"
 	},
 	"require-dev": {
 		"ergebnis/composer-normalize": "^2.28",


### PR DESCRIPTION
The command won't run anymore when using recent symfony/console library.

Additionally:

- The symfony/console package is added as an explicit requirement to composer.json.
- PHP 8.3 is added to composer.json.
- TYPO3 12 LTS is now a requirement.