### PR TITLE
[BUGFIX] Handle `@internal` correctly

### DIFF
--- a/Classes/Util/ClassDocsHelper.php
+++ b/Classes/Util/ClassDocsHelper.php
@@ -286,7 +286,7 @@ The following list contains all public classes in namespace :php:`%s`.
 
         $classReflection = self::getClassReflection($class);
         $isInternal = is_string($classReflection->getDocComment())
-            && str_contains($classReflection->getDocComment(), '@internal');
+            && str_contains($classReflection->getDocComment(), '* @internal');
         if ($isInternal && !$config['includeInternal']) {
             throw new ClassNotPublicException('Class ' . $class . ' is marked as internal.');
         }
@@ -577,7 +577,7 @@ The following list contains all public classes in namespace :php:`%s`.
     ): string {
         $methodReflection = self::getMethodReflection($class, $method);
         $isInternal = is_string($methodReflection->getDocComment())
-            && str_contains($methodReflection->getDocComment(), '@internal');
+            && str_contains($methodReflection->getDocComment(), '* @internal');
         // For some reason $methodReflection->isInternal() is always false
         if (
             (!$allowInternal && $isInternal)


### PR DESCRIPTION
In a code snippet, `@internal` might be used at the beginning of a line like

    /**
     * @internal
     */

But also in a line:

    /**
     * Registered listener can *set* a modified setup config AST. Note the TypoScript AST
     * structure is still marked @internal within v13 core and may change later,
     * using the event to *write* different 'config' data is thus still a bit risky.
     */

The latter should not be recognized as internal.