### PR TITLE
[BUGFIX] Move abstract modifier to property

### DIFF
--- a/Classes/Util/ClassDocsHelper.php
+++ b/Classes/Util/ClassDocsHelper.php
@@ -518,7 +518,7 @@ The following list contains all public classes in namespace :php:`%s`.
         }
         $result[] = "\n\n";
         if ($comment) {
-            $result[] = StringHelper::indentMultilineText($comment, '   ') . . "\n\n";
+            $result[] = StringHelper::indentMultilineText($comment, '   ') . "\n\n";
         }
 
         // SplFileObject locks the file, so null it when no longer needed


### PR DESCRIPTION
The abstract as part of the classname causes error in the new rendering