### PR TITLE
Add empty string as default value for

### DIFF
--- a/Classes/Util/ClassDocsHelper.php
+++ b/Classes/Util/ClassDocsHelper.php
@@ -795,9 +795,12 @@ The following list contains all public classes in namespace :php:`%s`.
             $result[] = StringHelper::indentMultilineText($code, '    ');
             $result[] = "\n\n";
         }
+
         if ($includeMethodParameters && $parameterInRst) {
             $result[] = implode("\n", $parameterInRst) . "\n";
         }
+
+        $returnPart = '';
         if ($returnType instanceof \ReflectionUnionType or $returnType instanceof \ReflectionNamedType && $returnType->getName() != 'void') {
             $typeNames = '';
             if ($returnType instanceof \ReflectionNamedType) {
@@ -821,6 +824,7 @@ The following list contains all public classes in namespace :php:`%s`.
         if ($noindexInClassMembers) {
             $methodHead .= '    :noindex:' . "\n";
         }
+
         if ($includeMethodParameters) {
             $methodHead .= $returnPart . "\n";
         }


### PR DESCRIPTION
There was a PHP warning in ClassDocsHelper at line 825 because `$returnPath` was an unknown variable. I have set it to empty string a few lines before now.